### PR TITLE
Add new PVC and reference as blob specific mount in values [semver:major]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,20 @@ resource "kubectl_manifest" "istio_virtualservice_nexus" {
   ]
 }
 
+resource "kubectl_manifest" "nexus_blob_pvc" {
+  force_new = true
+  yaml_body = templatefile(
+    "${path.module}/templates/blob-pvc.yaml.tpl",
+    {
+      namespace = var.namespace,
+      size      = "20Gi"
+    }
+  )
+  depends_on = [
+    kubernetes_namespace.nexus_namespace
+  ]
+}
+
 resource "helm_release" "nexus" {
 
   name = "nxrm"
@@ -44,7 +58,8 @@ resource "helm_release" "nexus" {
   depends_on = [
     kubernetes_namespace.nexus_namespace,
     kubernetes_storage_class.expandable,
-    kubectl_manifest.istio_virtualservice_nexus
+    kubectl_manifest.istio_virtualservice_nexus,
+    kubectl_manifest.nexus_blob_pvc
   ]
 
   timeout = 600

--- a/values.yaml
+++ b/values.yaml
@@ -104,7 +104,13 @@ deployment:
   terminationGracePeriodSeconds: 120
   additionalContainers:
   additionalVolumes:
+    - name: nexus-blobs
+      persistentVolumeClaim:
+        claimName: nexus-blob-storage
+
   additionalVolumeMounts:
+    - mountPath: /nexus-data/blobs
+      name: nexus-blobs
 
 ingress:
   enabled: false
@@ -154,7 +160,7 @@ persistence:
   # annotations:
   #  "helm.sh/resource-policy": keep
   storageClass: nexus-gp2
-  storageSize: 20Gi
+  storageSize: 8Gi #blobs live elsewhere  Should only really need1-2G, but DB has a 4G safety buffer.
   # If PersistentDisk already exists you can create a PV for it by including the 2 following keypairs.
   # pdName: nexus-data-disk
   # fsType: ext4


### PR DESCRIPTION
Nexus puts all data in /nexus-data, including blobs.  We mount a new volume under /nexus-data/blobs which is default blob storage path.

This should also reduces the size of the data path to 8gi, since it really should only need 1-2 plus the storage.diskCache.diskFreeSpaceLimit of kafka at 4G.

The new blob only storage is 20g (prod currently using 9.

If we do exceed blob space the nexus data dir should still have headroom to purge via UI